### PR TITLE
Fix fetching category alias

### DIFF
--- a/src/Frontend/Modules/NavigationBlock/Widgets/Detail.php
+++ b/src/Frontend/Modules/NavigationBlock/Widgets/Detail.php
@@ -28,7 +28,7 @@ class Detail extends FrontendBaseWidget
         parent::execute();
 
         $templateFile = null;
-        $categoryAlias = !empty($this->data['extra_label']) ? SpoonFilter::toCamelCase($this->data['extra_label']) : null;
+        $categoryAlias = !empty($this->data['extra_label']) ? SpoonFilter::toCamelCase($this->data['extra_label']) : (!empty($this->data['id']) ?  SpoonFilter::toCamelCase($this->data['id']) : null);
         if ($categoryAlias) {
             $templateFile = $this->getMyTemplate($categoryAlias);
         }


### PR DESCRIPTION
Fixes the fetch for a category alias when using {$var|parsewidget:"NavigationBlock":"Detail":"CategoryAlias"} directly in (f.e. footer) template.
